### PR TITLE
Modify code to avoid some potential danger

### DIFF
--- a/mcs.h
+++ b/mcs.h
@@ -1,3 +1,15 @@
+#ifndef _MCS_H_
+#define _MCS_H_
+
+#define MCS_TCP_INIT_ERROR -1
+#define MCS_TCP_SOCKET_INIT_ERROR 0x1
+#define MCS_TCP_DISCONNECT 0x2
+
+typedef void (*mcs_tcp_callback_t)(char *);
+typedef void (*mcs_mqtt_callback_t)(char *);
+
 void mcs_upload_datapoint(char *);
-void mcs_tcp_init(void (*mcs_tcp_callback)(char *));
+int32_t mcs_tcp_init(void (*mcs_tcp_callback)(char *));
 void mcs_mqtt_init(void (*mcs_mqtt_callback)(char *));
+
+#endif


### PR DESCRIPTION
Change log
. add mcs_splitn (reentrant version of mcs_split)
. add return value for getInitialTCPIP
. add return value check when calling getInitialTCPIP in mcs_tcp_init
. add error macro for mcs_tcp_init
. add callback function pointer typedef
. add C header guard
. modify mcs_tcp_init stack overflow avoidance (retry connect by goto jump)
. modify mcs_tcp_init return value type to int32_t
. modify getInitialTCPIP return value type to HTTPCLIENT_RESULT
. use mcs_splitn in mcs_tcp_init
